### PR TITLE
[fix] filename could contain illegal char

### DIFF
--- a/src/labelformat/formats/labelbox.py
+++ b/src/labelformat/formats/labelbox.py
@@ -3,7 +3,7 @@ import logging
 import re
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Optional
 
 from labelformat import utils
 from labelformat.cli.registry import Task, cli_register
@@ -19,6 +19,8 @@ from labelformat.model.object_detection import (
 from labelformat.types import JsonDict, ParseError
 
 logger = logging.getLogger(__name__)
+
+FILENAME_KEYS = ["global_key", "external_id", "id"]  # valid filename keys
 
 
 @cli_register(format="labelbox", task=Task.OBJECT_DETECTION)
@@ -39,15 +41,15 @@ class LabelboxObjectDetectionInput(ObjectDetectionInput):
         )
 
     def __init__(
-        self,
-        input_file: Path,
-        category_names: str,
+        self, input_file: Path, category_names: str, filename_key: str = "global_key"
     ) -> None:
         self._input_file = input_file
         self._categories = [
             Category(id=idx, name=name)
             for idx, name in enumerate(category_names.split(","))
         ]
+        self._validate_filename_key(filename_key)
+        self._filename_key = filename_key
 
     def get_categories(self) -> Iterable[Category]:
         return self._categories
@@ -56,7 +58,7 @@ class LabelboxObjectDetectionInput(ObjectDetectionInput):
         for label in self.get_labels():
             yield label.image
 
-    def get_labels(self, filename_key: str = None) -> Iterable[ImageObjectDetection]:
+    def get_labels(self) -> Iterable[ImageObjectDetection]:
         category_name_to_category = {cat.name: cat for cat in self._categories}
 
         with self._input_file.open() as file:
@@ -69,7 +71,7 @@ class LabelboxObjectDetectionInput(ObjectDetectionInput):
                         category_name_to_category=category_name_to_category,
                         image_id=image_id,
                         data_row=data_row,
-                        filename_key=filename_key,
+                        filename_key=self._filename_key,
                     )
                 except ParseError as ex:
                     raise ParseError(
@@ -78,14 +80,23 @@ class LabelboxObjectDetectionInput(ObjectDetectionInput):
 
                 image_id += 1
 
+    def _validate_filename_key(self, filename_key: str) -> None:
+        """Validates the provided filename key."""
+        if filename_key not in FILENAME_KEYS:
+            raise ParseError(
+                f"Filename key '{filename_key}' is not a valid option, please use one of {FILENAME_KEYS}"
+            )
+
 
 def _parse_data_row(
     category_name_to_category: Dict[str, Category],
     image_id: int,
     data_row: JsonDict,
-    filename_key: str = None,
+    filename_key: Optional[str] = None,
 ) -> ImageObjectDetection:
-    image = _image_from_data_row(image_id=image_id, data_row=data_row, filename_key=filename_key)
+    image = _image_from_data_row(
+        image_id=image_id, data_row=data_row, filename_key=filename_key
+    )
     objects = _objects_from_data_row(
         category_name_to_category=category_name_to_category,
         data_row=data_row,
@@ -93,34 +104,25 @@ def _parse_data_row(
     return ImageObjectDetection(image=image, objects=objects)
 
 
-def has_illegal_char(filename: str) -> bool:
+def _has_illegal_char(filename: str) -> bool:
     """Checks if filename contains illegal characters for filenames"""
     return bool(re.search(r'[\\/*?:"<>|]', filename))
 
 
-def _image_from_data_row(image_id: int, data_row: JsonDict, filename_key: str = None) -> Image:
-    fn_keys = ["global_key", "external_id", "id"]
-    if filename_key is not None:
-        # use filename_key if it is valid
-        assert filename_key in fn_keys, \
-            f"Filename key '{filename_key}' is not a valid option, please use one of {fn_keys}"
-        assert has_illegal_char(data_row["data_row"][filename_key]) == False, \
-            (f"Filename key '{filename_key}' contains illegal characters for filenames, "
-             f"please use another option among {fn_keys}")
-        assert filename_key in data_row["data_row"], \
-            f"Filename key '{filename_key}' does not exist in data_row: {data_row['data_row']}"
-        filename = data_row["data_row"][filename_key]
-    else:
-        # try to use one of fn_keys as filename
-        for key in fn_keys:
-            if key in data_row["data_row"] and not has_illegal_char(data_row["data_row"][key]):
-                filename = data_row["data_row"][key]
-                break
-        else:
-            raise ParseError(
-                f"Could not parse image filename from data row: {data_row['data_row']}. None of 'data_row.id', "
-                f"'data_row.global_key' nor 'data_row.external_id' existed or in the legal format for a filename."
-            )
+def _image_from_data_row(
+    image_id: int, data_row: JsonDict, filename_key: Optional[str] = None
+) -> Image:
+    if filename_key not in data_row["data_row"]:
+        raise ParseError(
+            f"Filename key '{filename_key}' not found in data_row: {data_row['data_row']}"
+        )
+
+    if _has_illegal_char(data_row["data_row"][filename_key]):
+        raise ParseError(
+            f"Filename key '{filename_key}' contains illegal characters, "
+            f"choose a different key among {FILENAME_KEYS}."
+        )
+    filename = data_row["data_row"][filename_key]
 
     width = data_row["media_attributes"]["width"]
     height = data_row["media_attributes"]["height"]

--- a/tests/unit/formats/test_labelbox.py
+++ b/tests/unit/formats/test_labelbox.py
@@ -1,39 +1,48 @@
 import pytest
 
-from labelformat.formats.labelbox import _has_illegal_char, _image_from_data_row
+from labelformat.formats import labelbox
+from labelformat.formats.labelbox import FilenameKeyOption
 from labelformat.types import ParseError
 
 
-class TestLabelboxFunctions:
-    def test_has_illegal_char(self) -> None:
-        assert _has_illegal_char("filename/with/slash")
-        assert _has_illegal_char("filename\\with\\backslash")
-        assert _has_illegal_char("filename:with:colon")
-        assert not _has_illegal_char("valid_filename")
+def test_has_illegal_char() -> None:
+    assert labelbox._has_illegal_char("filename/with/slash")
+    assert labelbox._has_illegal_char("filename\\with\\backslash")
+    assert labelbox._has_illegal_char("filename:with:colon")
+    assert not labelbox._has_illegal_char("valid_filename")
 
-    def test_image_from_data_row_valid(self) -> None:
-        data_row = {
-            "data_row": {"global_key": "image123", "id": "123"},
-            "media_attributes": {"width": 800, "height": 600},
-        }
-        image = _image_from_data_row(1, data_row, "global_key")
-        assert image.id == 1
-        assert image.filename == "image123"
-        assert image.width == 800
-        assert image.height == 600
 
-    def test_image_from_data_row_illegal_char(self) -> None:
-        data_row = {
-            "data_row": {"global_key": "image/123", "id": "123"},
-            "media_attributes": {"width": 800, "height": 600},
-        }
-        with pytest.raises(ParseError):
-            _image_from_data_row(1, data_row, "global_key")
+def test_image_from_data_row__valid() -> None:
+    data_row = {
+        "data_row": {"global_key": "image123", "id": "123"},
+        "media_attributes": {"width": 800, "height": 600},
+    }
+    image = labelbox._image_from_data_row(
+        image_id=1, data_row=data_row, filename_key=FilenameKeyOption.GLOBAL_KEY
+    )
+    assert image.id == 1
+    assert image.filename == "image123"
+    assert image.width == 800
+    assert image.height == 600
 
-    def test_image_from_data_row_key_not_found(self) -> None:
-        data_row = {
-            "data_row": {"id": "123"},
-            "media_attributes": {"width": 800, "height": 600},
-        }
-        with pytest.raises(ParseError):
-            _image_from_data_row(1, data_row, "global_key")
+
+def test_image_from_data_row__illegal_char() -> None:
+    data_row = {
+        "data_row": {"global_key": "image/123", "id": "123"},
+        "media_attributes": {"width": 800, "height": 600},
+    }
+    with pytest.raises(ParseError):
+        labelbox._image_from_data_row(
+            image_id=1, data_row=data_row, filename_key=FilenameKeyOption.GLOBAL_KEY
+        )
+
+
+def test_image_from_data_row__key_not_found() -> None:
+    data_row = {
+        "data_row": {"id": "123"},
+        "media_attributes": {"width": 800, "height": 600},
+    }
+    with pytest.raises(ParseError):
+        labelbox._image_from_data_row(
+            image_id=1, data_row=data_row, filename_key=FilenameKeyOption.GLOBAL_KEY
+        )

--- a/tests/unit/formats/test_labelbox.py
+++ b/tests/unit/formats/test_labelbox.py
@@ -1,0 +1,39 @@
+import pytest
+
+from labelformat.formats.labelbox import _has_illegal_char, _image_from_data_row
+from labelformat.types import ParseError
+
+
+class TestLabelboxFunctions:
+    def test_has_illegal_char(self) -> None:
+        assert _has_illegal_char("filename/with/slash")
+        assert _has_illegal_char("filename\\with\\backslash")
+        assert _has_illegal_char("filename:with:colon")
+        assert not _has_illegal_char("valid_filename")
+
+    def test_image_from_data_row_valid(self) -> None:
+        data_row = {
+            "data_row": {"global_key": "image123", "id": "123"},
+            "media_attributes": {"width": 800, "height": 600},
+        }
+        image = _image_from_data_row(1, data_row, "global_key")
+        assert image.id == 1
+        assert image.filename == "image123"
+        assert image.width == 800
+        assert image.height == 600
+
+    def test_image_from_data_row_illegal_char(self) -> None:
+        data_row = {
+            "data_row": {"global_key": "image/123", "id": "123"},
+            "media_attributes": {"width": 800, "height": 600},
+        }
+        with pytest.raises(ParseError):
+            _image_from_data_row(1, data_row, "global_key")
+
+    def test_image_from_data_row_key_not_found(self) -> None:
+        data_row = {
+            "data_row": {"id": "123"},
+            "media_attributes": {"width": 800, "height": 600},
+        }
+        with pytest.raises(ParseError):
+            _image_from_data_row(1, data_row, "global_key")


### PR DESCRIPTION
**Issue:** #6 

Previous code used `global_key` or `external_id` as filename, but according to LabelBox documentation, they could contain illegal characters for a filename, e.g. a POSIX path separator `/`, which leads to an unexpected file path when used as a filename.

**Improvement as follows:**

1. offer an option to specify which key (among `global_key`, `external_id` and `id`) in data_row to use as filename.
2. when `filename_key` is not specified, try different options as previous code did, but also check for illegal characters.
3. default behavior (when `filename_key` is not give) is mostly not changed.