### PR TITLE
fix output of lightly objects when the filename contains subdirs

### DIFF
--- a/src/labelformat/formats/lightly.py
+++ b/src/labelformat/formats/lightly.py
@@ -160,5 +160,6 @@ class LightlyObjectDetectionOutput(ObjectDetectionOutput):
             label_file = (self._output_folder / f"{label.image.filename}").with_suffix(
                 ".json"
             )
+            label_file.parent.mkdir(parents=True, exist_ok=True)
             with label_file.open("w") as file:
                 json.dump(data, file, indent=2)

--- a/tests/simple_object_detection_label_input.py
+++ b/tests/simple_object_detection_label_input.py
@@ -12,6 +12,9 @@ from labelformat.model.object_detection import (
 
 
 class SimpleObjectDetectionInput(ObjectDetectionInput):
+    def __init__(self, filename: str = "image.jpg"):
+        self.filename = filename
+
     def get_categories(self) -> Iterable[Category]:
         return [
             Category(id=0, name="cat"),
@@ -21,13 +24,13 @@ class SimpleObjectDetectionInput(ObjectDetectionInput):
 
     def get_images(self) -> Iterable[Image]:
         return [
-            Image(id=0, filename="image.jpg", width=100, height=200),
+            Image(id=0, filename=self.filename, width=100, height=200),
         ]
 
     def get_labels(self) -> Iterable[ImageObjectDetection]:
         return [
             ImageObjectDetection(
-                image=Image(id=0, filename="image.jpg", width=100, height=200),
+                image=Image(id=0, filename=self.filename, width=100, height=200),
                 objects=[
                     SingleObjectDetection(
                         category=Category(id=1, name="dog"),


### PR DESCRIPTION
## Description

I encountered this error during my labelQA experiment: When the filename contains a subdir, it is not guaranteed that the subdir exists yet, which may lead to an error.

## Tests

I first created an adapted unittest, which failed. Then the one-line fix fixed it.