### PR TITLE
Allow missing labels for yolo is

### DIFF
--- a/src/labelformat/formats/yolov8.py
+++ b/src/labelformat/formats/yolov8.py
@@ -115,15 +115,20 @@ class YOLOv8ObjectDetectionInput(_YOLOv8BaseInput, ObjectDetectionInput):
             try:
                 with label_path.open() as file:
                     label_data = [line.strip().split() for line in file if line.strip()]
-            except Exception as e:
+            except (FileNotFoundError, PermissionError, IsADirectoryError) as e:
                 logger.error(
-                    f"Error reading label file '{label_path}' for image '{image.filename}': {e}"
+                    f"Failed to access label file '{label_path}' for image '{image.filename}': {e}"
+                )
+                continue  # Skip processing this image due to access error
+            except (OSError, UnicodeDecodeError) as e:
+                logger.error(
+                    f"Error reading contents of label file '{label_path}' for image '{image.filename}': {e}"
                 )
                 continue  # Skip processing this image due to read error
 
             objects = []
             for entry in label_data:
-                if len(entry) < 5:
+                if len(entry) != 5:
                     logger.warning(
                         f"Invalid label format in file '{label_path}' for image '{image.filename}'. Skipping this annotation."
                     )

--- a/src/labelformat/formats/yolov8.py
+++ b/src/labelformat/formats/yolov8.py
@@ -110,21 +110,21 @@ class YOLOv8ObjectDetectionInput(_YOLOv8BaseInput, ObjectDetectionInput):
                 logger.warning(
                     f"Label file '{label_path}' for image '{image.filename}' does not exist. Skipping this image."
                 )
-                continue  # Skip processing this image
+                continue
 
             try:
                 with label_path.open() as file:
                     label_data = [line.strip().split() for line in file if line.strip()]
-            except (FileNotFoundError, PermissionError, IsADirectoryError) as e:
+            except OSError as e:
                 logger.error(
                     f"Failed to access label file '{label_path}' for image '{image.filename}': {e}"
                 )
-                continue  # Skip processing this image due to access error
-            except (OSError, UnicodeDecodeError) as e:
+                continue
+            except ValueError as e:
                 logger.error(
                     f"Error reading contents of label file '{label_path}' for image '{image.filename}': {e}"
                 )
-                continue  # Skip processing this image due to read error
+                continue
 
             objects = []
             for entry in label_data:
@@ -132,7 +132,7 @@ class YOLOv8ObjectDetectionInput(_YOLOv8BaseInput, ObjectDetectionInput):
                     logger.warning(
                         f"Invalid label format in file '{label_path}' for image '{image.filename}'. Skipping this annotation."
                     )
-                    continue  # Skip invalid annotations
+                    continue
 
                 try:
                     category_id, rcx, rcy, rw, rh = entry
@@ -153,7 +153,7 @@ class YOLOv8ObjectDetectionInput(_YOLOv8BaseInput, ObjectDetectionInput):
                     logger.error(
                         f"Error processing annotation in file '{label_path}' for image '{image.filename}': {e}"
                     )
-                    continue  # Skip invalid annotations
+                    continue
 
             yield ImageObjectDetection(
                 image=image,

--- a/src/labelformat/utils.py
+++ b/src/labelformat/utils.py
@@ -36,7 +36,8 @@ def get_images_from_folder(folder: Path) -> Iterable[Image]:
             logger.debug(f"Skipping non-image file '{image_path}'")
             continue
         image_filename = str(image_path.relative_to(folder))
-        image_width, image_height = PIL.Image.open(image_path).size
+        with PIL.Image.open(image_path) as img:
+            image_width, image_height = img.size
         yield Image(
             id=image_id,
             filename=image_filename,

--- a/tests/integration/instance_segmentation/test_inverse.py
+++ b/tests/integration/instance_segmentation/test_inverse.py
@@ -54,4 +54,8 @@ def test_yolov8_inverse(tmp_path: Path, mocker: MockerFixture) -> None:
 def _mock_input_images(mocker: MockerFixture, folder: Path) -> None:
     folder.mkdir()
     (folder / "image.jpg").touch()
-    mocker.patch("PIL.Image.open", autospec=True).return_value.size = (100, 200)
+    mock_img = mocker.MagicMock()
+    mock_img.size = (100, 200)
+    mock_context_manager = mocker.MagicMock()
+    mock_context_manager.__enter__.return_value = mock_img
+    mocker.patch("PIL.Image.open", return_value=mock_context_manager)

--- a/tests/integration/object_detection/test_inverse.py
+++ b/tests/integration/object_detection/test_inverse.py
@@ -95,4 +95,8 @@ def test_lightly_inverse(tmp_path: Path, mocker: MockerFixture) -> None:
 def _mock_input_images(mocker: MockerFixture, folder: Path) -> None:
     folder.mkdir()
     (folder / "image.jpg").touch()
-    mocker.patch("PIL.Image.open", autospec=True).return_value.size = (100, 200)
+    mock_img = mocker.MagicMock()
+    mock_img.size = (100, 200)
+    mock_context_manager = mocker.MagicMock()
+    mock_context_manager.__enter__.return_value = mock_img
+    mocker.patch("PIL.Image.open", return_value=mock_context_manager)

--- a/tests/unit/formats/test_kitti.py
+++ b/tests/unit/formats/test_kitti.py
@@ -34,7 +34,11 @@ class TestKittiObjectDetectionInput:
         # Mock the image file.
         (tmp_path / "images").mkdir()
         (tmp_path / "images/image.jpg").touch()
-        mocker.patch("PIL.Image.open", autospec=True).return_value.size = (100, 200)
+        mock_img = mocker.MagicMock()
+        mock_img.size = (100, 200)
+        mock_context_manager = mocker.MagicMock()
+        mock_context_manager.__enter__.return_value = mock_img
+        mocker.patch("PIL.Image.open", return_value=mock_context_manager)
 
         # Convert.
         label_input = KittiObjectDetectionInput(

--- a/tests/unit/formats/test_lightly.py
+++ b/tests/unit/formats/test_lightly.py
@@ -72,7 +72,11 @@ class TestLightlyObjectDetectionInput:
         (tmp_path / "images/image.jpg").touch()
         (tmp_path / "images/subdir").mkdir(parents=True)
         (tmp_path / "images/subdir/image.jpg").touch()
-        mocker.patch("PIL.Image.open", autospec=True).return_value.size = (100, 200)
+        mock_img = mocker.MagicMock()
+        mock_img.size = (100, 200)
+        mock_context_manager = mocker.MagicMock()
+        mock_context_manager.__enter__.return_value = mock_img
+        mocker.patch("PIL.Image.open", return_value=mock_context_manager)
 
         # Convert.
         label_input = LightlyObjectDetectionInput(


### PR DESCRIPTION
## Changes

- This should fix a bug when loading YOLO format labels that have no label files for certain images (.txt files missing)
- It also resolves a warning that images are not properly freed by using a context manager
- Also had to update the test to mock the new context manager properly