### PR TITLE
Support alternative yolo yaml format loading

### DIFF
--- a/src/labelformat/formats/yolov8.py
+++ b/src/labelformat/formats/yolov8.py
@@ -95,7 +95,9 @@ class _YOLOv8BaseInput:
         yield from utils.get_images_from_folder(folder=self._images_dir())
 
     def _root_dir(self) -> Path:
-        return self._config_file.parent / str(self._config_data["path"])
+        if "path" in self._config_data:
+            return self._config_file.parent / str(self._config_data["path"])
+        return self._config_file.parent
 
     def _images_dir(self) -> Path:
         root_dir = self._root_dir()

--- a/src/labelformat/formats/yolov8.py
+++ b/src/labelformat/formats/yolov8.py
@@ -50,10 +50,45 @@ class _YOLOv8BaseInput:
             )
 
     def get_categories(self) -> Iterable[Category]:
-        for category_id, category_name in self._config_data["names"].items():
-            yield Category(
-                id=int(category_id),
-                name=category_name,
+        """Get categories from YOLOv8 config file.
+
+        Supports two formats for the 'names' field:
+        - dictionary mapping id to name
+          Example:
+          names:
+            0: person
+            1: dog
+            2: cat
+        - list of names where index is the id
+          Example:
+          names:
+            - person
+            - dog
+            - cat
+          or
+          names: [person, dog, cat]
+        Returns:
+            Iterator of Category objects.
+        """
+        names = self._config_data["names"]
+        if isinstance(names, dict):
+            # Original YOLOv8 format: dictionary mapping id to name
+            for category_id, category_name in names.items():
+                yield Category(
+                    id=int(category_id),
+                    name=category_name,
+                )
+        elif isinstance(names, list):
+            # Alternative YOLO format: list of names where index is the id
+            for category_id, category_name in enumerate(names):
+                yield Category(
+                    id=category_id,
+                    name=category_name,
+                )
+        else:
+            raise ValueError(
+                f"Invalid 'names' format in config file '{self._config_file}'. "
+                "Expected dictionary or list, got {type(names)}"
             )
 
     def get_images(self) -> Iterable[Image]:

--- a/src/labelformat/formats/yolov8.py
+++ b/src/labelformat/formats/yolov8.py
@@ -81,17 +81,13 @@ class _YOLOv8BaseInput:
         root_dir = self._root_dir()
         images_dir = self._images_dir()
         images_dir_name = str(images_dir.relative_to(root_dir))
-        images_subdir_index = images_dir_name.find("images")
-        if images_subdir_index != -1:
-            labels_dir_name = (
-                images_dir_name[:images_subdir_index]
-                + "labels"
-                + images_dir_name[images_subdir_index + len("images") :]
-            )
-        else:
+
+        if "images" not in images_dir_name:
             raise RuntimeError(
                 f"Could not find 'images' subdirectory in '{images_dir}'"
             )
+
+        labels_dir_name = images_dir_name.replace("images", "labels", 1)
         return root_dir / labels_dir_name
 
 

--- a/src/labelformat/formats/yolov8.py
+++ b/src/labelformat/formats/yolov8.py
@@ -50,51 +50,20 @@ class _YOLOv8BaseInput:
             )
 
     def get_categories(self) -> Iterable[Category]:
-        """Get categories from YOLOv8 config file.
-
-        Supports two formats for the 'names' field:
-        - dictionary mapping id to name
-          Example:
-          names:
-            0: person
-            1: dog
-            2: cat
-        - list of names where index is the id
-          Example:
-          names:
-            - person
-            - dog
-            - cat
-          or
-          names: [person, dog, cat]
-        Returns:
-            Iterator of Category objects.
-        """
+        """Get categories from YOLOv8 config file. Assumes contiguous 0-indexed labels."""
         names = self._config_data["names"]
-        if isinstance(names, dict):
-            # Original YOLOv8 format: dictionary mapping id to name
-            for category_id, category_name in names.items():
-                yield Category(
-                    id=int(category_id),
-                    name=category_name,
-                )
-        elif isinstance(names, list):
-            # Alternative YOLO format: list of names where index is the id
-            for category_id, category_name in enumerate(names):
-                yield Category(
-                    id=category_id,
-                    name=category_name,
-                )
-        else:
-            raise ValueError(
-                f"Invalid 'names' format in config file '{self._config_file}'. "
-                "Expected dictionary or list, got {type(names)}"
-            )
+        for category_id in range(len(names)):
+            yield Category(id=category_id, name=names[category_id])
 
     def get_images(self) -> Iterable[Image]:
         yield from utils.get_images_from_folder(folder=self._images_dir())
 
     def _root_dir(self) -> Path:
+        """Return the root directory of the dataset.
+
+        If the config file contains a "path" field, it is used as the root directory (ultralytics format).
+        Otherwise, the root directory is the parent of the config file (roboflow format).
+        """
         if "path" in self._config_data:
             return self._config_file.parent / str(self._config_data["path"])
         return self._config_file.parent

--- a/src/labelformat/formats/yolov8.py
+++ b/src/labelformat/formats/yolov8.py
@@ -104,11 +104,21 @@ class _YOLOv8BaseInput:
         return root_dir / str(self._config_data[self._split])
 
     def _labels_dir(self) -> Path:
+        """Get labels directory from YOLOv8 config file.
+
+        The labels directory is derived from the images directory by replacing
+        the first occurrence of 'images' with 'labels'.
+        """
         root_dir = self._root_dir()
         images_dir = self._images_dir()
         images_dir_name = str(images_dir.relative_to(root_dir))
-        if images_dir_name.startswith("images"):
-            labels_dir_name = "labels" + images_dir_name[len("images") :]
+        images_subdir_index = images_dir_name.find("images")
+        if images_subdir_index != -1:
+            labels_dir_name = (
+                images_dir_name[:images_subdir_index]
+                + "labels"
+                + images_dir_name[images_subdir_index + len("images") :]
+            )
         else:
             raise RuntimeError(
                 f"Could not find 'images' subdirectory in '{images_dir}'"

--- a/tests/unit/formats/test_yolov8.py
+++ b/tests/unit/formats/test_yolov8.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from pathlib import Path
+from typing import Dict, List, Union
 
 import pytest
 import yaml
@@ -8,7 +11,7 @@ from labelformat.model.category import Category
 
 
 @pytest.fixture
-def expected_categories():
+def expected_categories() -> List[Category]:
     return [
         Category(id=0, name="person"),
         Category(id=1, name="dog"),
@@ -16,7 +19,9 @@ def expected_categories():
     ]
 
 
-def test_get_categories_dict_format(tmp_path: Path, expected_categories) -> None:
+def test_get_categories_dict_format(
+    tmp_path: Path, expected_categories: List[Category]
+) -> None:
     config = {
         "path": ".",
         "train": "images",
@@ -31,8 +36,14 @@ def test_get_categories_dict_format(tmp_path: Path, expected_categories) -> None
     assert categories == expected_categories
 
 
-def test_get_categories_list_format(tmp_path: Path, expected_categories) -> None:
-    config = {"path": ".", "train": "images", "names": ["person", "dog", "cat"]}
+def test_get_categories_list_format(
+    tmp_path: Path, expected_categories: List[Category]
+) -> None:
+    config = {
+        "path": ".",
+        "train": "images",
+        "names": ["person", "dog", "cat"],
+    }
     config_file = tmp_path / "config.yaml"
     with config_file.open("w") as f:
         yaml.safe_dump(config, f)
@@ -42,8 +53,10 @@ def test_get_categories_list_format(tmp_path: Path, expected_categories) -> None
     assert categories == expected_categories
 
 
-def test_get_categories_yaml_block_format(tmp_path: Path, expected_categories) -> None:
-    config = """
+def test_get_categories_yaml_block_format(
+    tmp_path: Path, expected_categories: List[Category]
+) -> None:
+    config: str = """
     path: .
     train: images
     names:

--- a/tests/unit/formats/test_yolov8.py
+++ b/tests/unit/formats/test_yolov8.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from labelformat.formats.yolov8 import _YOLOv8BaseInput
+from labelformat.model.category import Category
+
+
+def test_get_categories_supports_list_and_dict_format(tmp_path: Path) -> None:
+    # Test dictionary format (original)
+    dict_config = {
+        "path": ".",
+        "train": "images",
+        "names": {0: "person", 1: "dog", 2: "cat"},
+    }
+    dict_file = tmp_path / "dict.yaml"
+    with dict_file.open("w") as f:
+        yaml.safe_dump(dict_config, f)
+
+    dict_input = _YOLOv8BaseInput(input_file=dict_file, input_split="train")
+    dict_categories = list(dict_input.get_categories())
+
+    # Test list format with explicit brackets
+    list_config = {"path": ".", "train": "images", "names": ["person", "dog", "cat"]}
+    list_file = tmp_path / "list.yaml"
+    with list_file.open("w") as f:
+        yaml.safe_dump(list_config, f)
+
+    list_input = _YOLOv8BaseInput(input_file=list_file, input_split="train")
+    list_categories = list(list_input.get_categories())
+
+    # Test list format with YAML block sequence
+    block_config = """
+    path: .
+    train: images
+    names:
+      - person
+      - dog
+      - cat
+    """
+    block_file = tmp_path / "block.yaml"
+    with block_file.open("w") as f:
+        f.write(block_config)
+
+    block_input = _YOLOv8BaseInput(input_file=block_file, input_split="train")
+    block_categories = list(block_input.get_categories())
+
+    # All formats should produce the same categories
+    expected = [
+        Category(id=0, name="person"),
+        Category(id=1, name="dog"),
+        Category(id=2, name="cat"),
+    ]
+    assert dict_categories == expected
+    assert list_categories == expected
+    assert block_categories == expected

--- a/tests/unit/formats/test_yolov8.py
+++ b/tests/unit/formats/test_yolov8.py
@@ -110,8 +110,68 @@ def test_invalid_names_format(tmp_path: Path) -> None:
         yaml.safe_dump(config, f)
 
     input_obj = _YOLOv8BaseInput(input_file=config_file, input_split="train")
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(TypeError):  # Will fail when trying to use len() on int
         list(input_obj.get_categories())
 
-    assert "Invalid 'names' format" in str(exc_info.value)
-    assert "Expected dictionary or list" in str(exc_info.value)
+
+def test_labels_dir_relative_to_path(tmp_path: Path) -> None:
+    """Test labels directory resolution for paths relative to dataset root."""
+    config = {
+        "path": "../datasets/coco8",
+        "train": "images/train",
+        "names": ["person"],
+    }
+    config_file = tmp_path / "config.yaml"
+    with config_file.open("w") as f:
+        yaml.safe_dump(config, f)
+
+    input_obj = _YOLOv8BaseInput(input_file=config_file, input_split="train")
+    expected = tmp_path / "../datasets/coco8/labels/train"
+    assert input_obj._labels_dir() == expected
+
+
+def test_labels_dir_absolute_path(tmp_path: Path) -> None:
+    """Test labels directory resolution for absolute paths."""
+    config = {
+        "path": ".",
+        "train": "../train/images",
+        "names": ["head", "helmet", "person"],
+    }
+    config_file = tmp_path / "config.yaml"
+    with config_file.open("w") as f:
+        yaml.safe_dump(config, f)
+
+    input_obj = _YOLOv8BaseInput(input_file=config_file, input_split="train")
+    expected = tmp_path / "../train/labels"
+    assert input_obj._labels_dir() == expected
+
+
+def test_labels_dir_with_images_in_path(tmp_path: Path) -> None:
+    """Test labels directory resolution when 'images' appears in the root path."""
+    config = {
+        "path": "mydataset/images/dataset1",
+        "train": "images/train",
+        "names": ["person"],
+    }
+    config_file = tmp_path / "config.yaml"
+    with config_file.open("w") as f:
+        yaml.safe_dump(config, f)
+
+    input_obj = _YOLOv8BaseInput(input_file=config_file, input_split="train")
+    expected = tmp_path / "mydataset/images/dataset1/labels/train"
+    assert input_obj._labels_dir() == expected
+
+
+def test_labels_dir_without_path(tmp_path: Path) -> None:
+    """Test labels directory resolution when 'path' is not specified in config."""
+    config = {
+        "train": "images/train",
+        "names": ["person"],
+    }
+    config_file = tmp_path / "config.yaml"
+    with config_file.open("w") as f:
+        yaml.safe_dump(config, f)
+
+    input_obj = _YOLOv8BaseInput(input_file=config_file, input_split="train")
+    expected = tmp_path / "labels/train"
+    assert input_obj._labels_dir() == expected


### PR DESCRIPTION
## Changes

For whatever reason there is no consistency with the YOLO format when it comes to the `names` field. Once it's a dictionary and once it's a list. This PR ensures that labelformat supports both formats.

[On Ultralytics docs](https://docs.ultralytics.com/datasets/detect/#coco-dataset-format-to-yolo-format) they describe the format as follows:
```yaml
path: ../datasets/coco8 # dataset root directory
train: images/train # training images (relative to 'path')
val: images/val # validation images (relative to 'path')
test: # optional test images
names:
    0: person
    1: bicycle
    2: car
    # ...
```

[And on Roboflow docs](https://roboflow.com/formats/yolov8-pytorch-txt) they describe the format as follows:
```yaml
train: ../train/images
val: ../valid/images

nc: 3
names: ['head', 'helmet', 'person']
```

- add support for loading both formats
- add unit tests
- modify the `_labels_dir` method to handle reverse directory structure (`images/train/img1.jpg` vs `train/images/img1.jpg`)
