### PR TITLE
Bump version to 0.1.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "labelformat"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Lightly.ai"]
 description = "A tool for converting computer vision label formats."
 readme = "README.md"

--- a/src/labelformat/formats/labelformat.py
+++ b/src/labelformat/formats/labelformat.py
@@ -23,7 +23,9 @@ class _CustomBaseInput:
 
     @staticmethod
     def add_cli_arguments(parser: ArgumentParser) -> None:
-        raise ValueError("LabelformatObjectDetectionInput does not support CLI arguments")
+        raise ValueError(
+            "LabelformatObjectDetectionInput does not support CLI arguments"
+        )
 
     def get_categories(self) -> Iterable[Category]:
         return self.categories


### PR DESCRIPTION
## Description
- Bumps the version o 0.1.7

- Fixes the formatting which was broken in a previous PR and not caught due to branch protection not being enabled. I just enabled it:
![image](https://github.com/user-attachments/assets/80731693-80b6-4a3f-9ea1-b3257247f6ad)
