### PR TITLE
Speed up SemanticSegmentationMask

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 

--- a/src/labelformat/formats/labelformat.py
+++ b/src/labelformat/formats/labelformat.py
@@ -36,7 +36,6 @@ class _CustomBaseInput:
 
 @dataclass
 class LabelformatObjectDetectionInput(_CustomBaseInput, ObjectDetectionInput):
-
     labels: list[ImageObjectDetection]
 
     """Class for custom object detection input format. 

--- a/src/labelformat/model/semantic_segmentation.py
+++ b/src/labelformat/model/semantic_segmentation.py
@@ -33,43 +33,48 @@ class SemanticSegmentationMask:
         if array.ndim != 2:
             raise ValueError("SemSegMask.array must be 2D with shape (H, W).")
 
-        category_id_rle: list[tuple[int, int]] = []
+        if array.size == 0:
+            return cls(
+                category_id_rle=[],
+                width=array.shape[1],
+                height=array.shape[0],
+            )
 
-        cur_cat_id: int | None = None
-        cur_run_length = 0
-        for cat_id in array.flatten():
-            if cat_id == cur_cat_id:
-                cur_run_length += 1
-            else:
-                if cur_cat_id is not None:
-                    category_id_rle.append((cur_cat_id, cur_run_length))
-                cur_cat_id = int(cat_id)
-                cur_run_length = 1
-        if cur_cat_id is not None:
-            category_id_rle.append((cur_cat_id, cur_run_length))
+        flat = array.ravel()
+        change_indices = np.nonzero(flat[:-1] != flat[1:])[0]
+        run_starts = np.concatenate(([0], change_indices + 1))
+        run_lengths = np.diff(np.concatenate(([0], change_indices + 1, [flat.size])))
+
+        category_ids = flat[run_starts]
+        category_id_rle = list(zip(category_ids.tolist(), run_lengths.tolist()))
 
         return cls(
-            category_id_rle=category_id_rle, width=array.shape[1], height=array.shape[0]
+            category_id_rle=category_id_rle,
+            width=array.shape[1],
+            height=array.shape[0],
         )
 
     def to_binary_mask(self, category_id: int) -> BinaryMaskSegmentation:
         """Get a binary mask for a given category ID."""
-        binary_rle = []
+        if not self.category_id_rle:
+            return BinaryMaskSegmentation.from_rle(
+                rle_row_wise=[],
+                width=self.width,
+                height=self.height,
+            )
 
-        symbol = 0
-        run_length = 0
-        for cat_id, cur_run_length in self.category_id_rle:
-            cur_symbol = 1 if cat_id == category_id else 0
-            if symbol == cur_symbol:
-                run_length += cur_run_length
-            else:
-                binary_rle.append(run_length)
-                symbol = cur_symbol
-                run_length = cur_run_length
+        rle_array = np.asarray(self.category_id_rle, dtype=np.int_)
+        cat_ids = rle_array[:, 0]
+        run_lengths = rle_array[:, 1]
+        symbols = cat_ids == category_id
+        change_indices = np.nonzero(symbols[:-1] != symbols[1:])[0] + 1
+        run_starts = np.concatenate(([0], change_indices))
+        binary_run_lengths = np.add.reduceat(run_lengths, run_starts)
+        if symbols[0]:
+            binary_run_lengths = np.concatenate(([0], binary_run_lengths))
 
-        binary_rle.append(run_length)
         return BinaryMaskSegmentation.from_rle(
-            rle_row_wise=binary_rle,
+            rle_row_wise=binary_run_lengths.tolist(),
             width=self.width,
             height=self.height,
         )

--- a/tests/unit/model/test_semantic_segmentation.py
+++ b/tests/unit/model/test_semantic_segmentation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from labelformat.model.bounding_box import BoundingBox
 from labelformat.model.semantic_segmentation import SemanticSegmentationMask
 
 
@@ -38,6 +39,8 @@ class TestSemanticSegmentationMask:
             )
         )
         binary_mask = mask.to_binary_mask(category_id=1)
+        assert binary_mask.get_rle() == [0, 2, 3, 3, 4]
+        assert binary_mask.bounding_box == BoundingBox(0, 0, 4, 2)
         assert binary_mask.get_binary_mask().tolist() == [
             [1, 1, 0, 0],
             [0, 1, 1, 1],
@@ -45,6 +48,8 @@ class TestSemanticSegmentationMask:
         ]
 
         binary_mask = mask.to_binary_mask(category_id=2)
+        assert binary_mask.get_rle() == [2, 3, 7]
+        assert binary_mask.bounding_box == BoundingBox(0, 0, 4, 2)
         assert binary_mask.get_binary_mask().tolist() == [
             [0, 0, 1, 1],
             [1, 0, 0, 0],
@@ -52,11 +57,27 @@ class TestSemanticSegmentationMask:
         ]
 
         binary_mask = mask.to_binary_mask(category_id=4)
+        assert binary_mask.get_rle() == [12]
+        assert binary_mask.bounding_box == BoundingBox(4, 3, 0, 0)
         assert binary_mask.get_binary_mask().tolist() == [
             [0, 0, 0, 0],
             [0, 0, 0, 0],
             [0, 0, 0, 0],
         ]
+
+    def test_empty_mask(self) -> None:
+        mask = SemanticSegmentationMask.from_array(
+            array=np.empty((0, 3), dtype=np.int_)
+        )
+        assert mask.category_id_rle == []
+        assert mask.width == 3
+        assert mask.height == 0
+        assert mask.category_ids() == set()
+
+        binary_mask = mask.to_binary_mask(category_id=1)
+        assert binary_mask.get_rle() == []
+        assert binary_mask.bounding_box == BoundingBox(3, 0, 0, 0)
+        assert binary_mask.get_binary_mask().shape == (0, 3)
 
     def test_category_ids(self) -> None:
         mask = SemanticSegmentationMask.from_array(

--- a/tests/unit/model/test_semantic_segmentation.py
+++ b/tests/unit/model/test_semantic_segmentation.py
@@ -65,7 +65,7 @@ class TestSemanticSegmentationMask:
             [0, 0, 0, 0],
         ]
 
-    def test_empty_mask(self) -> None:
+    def test__empty_mask(self) -> None:
         mask = SemanticSegmentationMask.from_array(
             array=np.empty((0, 3), dtype=np.int_)
         )


### PR DESCRIPTION
## What has changed and why?
Use numpy vectorized operations instead of Python for loops.

I've also updated GitHub actions to newer versions (Node 20 will be turned off tomorrow).

## How has it been tested?
Existing tests that I've improved.