### PR TITLE
Add opt-in on_error hook for unreadable images during folder scan

### DIFF
--- a/src/labelformat/formats/kitti.py
+++ b/src/labelformat/formats/kitti.py
@@ -1,7 +1,7 @@
 import logging
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Optional
 
 from labelformat import utils
 from labelformat.cli.registry import Task, cli_register
@@ -49,6 +49,9 @@ class KittiObjectDetectionInput(ObjectDetectionInput):
     ) -> None:
         self._input_folder = input_folder
         self._images_rel_path = images_rel_path
+        # Optional hook to tolerate unreadable images during folder scan.
+        # Default None re-raises; see utils.get_images_from_folder.
+        self.on_error: Optional[utils.OnImageErrorHook] = None
         self._categories = [
             Category(id=idx, name=name)
             for idx, name in enumerate(category_names.split(","))
@@ -59,7 +62,8 @@ class KittiObjectDetectionInput(ObjectDetectionInput):
 
     def get_images(self) -> Iterable[Image]:
         yield from utils.get_images_from_folder(
-            folder=self._input_folder / self._images_rel_path
+            folder=self._input_folder / self._images_rel_path,
+            on_error=self.on_error,
         )
 
     def get_labels(self) -> Iterable[ImageObjectDetection]:

--- a/src/labelformat/formats/lightly.py
+++ b/src/labelformat/formats/lightly.py
@@ -2,7 +2,7 @@ import copy
 import json
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Sequence
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 from labelformat import utils
 from labelformat.cli.registry import Task, cli_register
@@ -49,6 +49,9 @@ class LightlyObjectDetectionInput(ObjectDetectionInput):
         self._input_folder = input_folder
         self._images_rel_path = images_rel_path
         self._skip_labels_without_image = skip_labels_without_image
+        # Optional hook to tolerate unreadable images during folder scan.
+        # Default None re-raises; see utils.get_images_from_folder.
+        self.on_error: Optional[utils.OnImageErrorHook] = None
         self._categories = self._get_categories()
 
     def get_categories(self) -> Iterable[Category]:
@@ -56,7 +59,8 @@ class LightlyObjectDetectionInput(ObjectDetectionInput):
 
     def get_images(self) -> Iterable[Image]:
         yield from utils.get_images_from_folder(
-            folder=self._input_folder / self._images_rel_path
+            folder=self._input_folder / self._images_rel_path,
+            on_error=self.on_error,
         )
 
     def get_labels(self) -> Iterable[ImageObjectDetection]:

--- a/src/labelformat/formats/maskpair.py
+++ b/src/labelformat/formats/maskpair.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Iterable, List, Literal, Union
+from typing import Iterable, List, Literal, Optional, Union
 
 from labelformat.cli.registry import Task, cli_register
 from labelformat.mask_utils import (
@@ -23,7 +23,11 @@ from labelformat.model.instance_segmentation import (
     SingleInstanceSegmentation,
 )
 from labelformat.model.multipolygon import MultiPolygon
-from labelformat.utils import get_image_dimensions
+from labelformat.utils import (
+    ImageDimensionError,
+    OnImageErrorHook,
+    get_image_dimensions,
+)
 
 
 @cli_register(format="maskpair", task=Task.INSTANCE_SEGMENTATION)
@@ -128,6 +132,9 @@ class MaskPairInstanceSegmentationInput(InstanceSegmentationInput):
         self._morph_close = morph_close
         self._segmentation_type = segmentation_type
         self._approx_epsilon = approx_epsilon
+        # Optional hook to tolerate unreadable images during folder scan.
+        # Default None re-raises; see utils.get_images_from_folder.
+        self.on_error: Optional[OnImageErrorHook] = None
 
         # Parse category names
         self._categories = []
@@ -147,9 +154,20 @@ class MaskPairInstanceSegmentationInput(InstanceSegmentationInput):
         yield from self._categories
 
     def get_images(self) -> Iterable[Image]:
-        """Get images from the image/mask pairs."""
+        """Get images from the image/mask pairs.
+
+        Image ids are the positional index into the image/mask pairs so that
+        they stay aligned with ``get_labels()``. Images skipped via ``on_error``
+        leave a gap in the id sequence.
+        """
         for image_id, (image_path, _) in enumerate(self._image_mask_pairs):
-            width, height = get_image_dimensions(image_path)
+            try:
+                width, height = get_image_dimensions(image_path)
+            except ImageDimensionError as error:
+                if self.on_error is None:
+                    raise
+                self.on_error(Path(image_path), error)
+                continue
             yield Image(
                 id=image_id,
                 filename=image_path.name,
@@ -162,6 +180,11 @@ class MaskPairInstanceSegmentationInput(InstanceSegmentationInput):
         images = {img.id: img for img in self.get_images()}
 
         for image_id, (image_path, mask_path) in enumerate(self._image_mask_pairs):
+            # Skip pairs whose image was dropped by the on_error hook in
+            # get_images() so labels stay aligned with readable images.
+            if image_id not in images:
+                continue
+
             # Load and binarize the mask
             binary_mask = binarize_mask(
                 mask_path=mask_path,

--- a/src/labelformat/formats/semantic_segmentation/pascalvoc.py
+++ b/src/labelformat/formats/semantic_segmentation/pascalvoc.py
@@ -14,6 +14,7 @@ from argparse import ArgumentParser
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
+from typing import Optional
 
 import numpy as np
 from fsspec.core import url_to_fs
@@ -65,6 +66,7 @@ class PascalVOCSemanticSegmentationInput(InstanceSegmentationInput):
         images_dir: PathLike,
         masks_dir: PathLike,
         class_id_to_name: Mapping[int, str],
+        on_error: Optional[utils.OnImageErrorHook] = None,
     ) -> "PascalVOCSemanticSegmentationInput":
         """Create a PascalVOCSemanticSegmentationInput from directory pairs.
 
@@ -73,6 +75,10 @@ class PascalVOCSemanticSegmentationInput(InstanceSegmentationInput):
             masks_dir: Root directory or URI containing PNG masks mirroring images
                 structure.
             class_id_to_name: Mapping of class_id -> class name, with integer keys.
+            on_error: Optional hook invoked when an image cannot be read during the
+                folder scan. When ``None`` (the default), a failure raises
+                ``ImageDimensionError``. When provided, the hook is called with the
+                offending path and the error, and the image is skipped.
 
         Raises:
             ValueError: If directories are invalid, a mask is missing or not PNG,
@@ -93,7 +99,7 @@ class PascalVOCSemanticSegmentationInput(InstanceSegmentationInput):
 
         # Collect images using helper and ensure a PNG mask exists for each.
         images_by_filename: dict[str, Image] = {}
-        for img in utils.get_images_from_folder(images_dir):
+        for img in utils.get_images_from_folder(images_dir, on_error=on_error):
             mask_rel_path = str(PurePosixPath(img.filename).with_suffix(".png"))
             mask_path = posixpath.join(masks_fs_dir, mask_rel_path)
             if not masks_fs.isfile(mask_path):

--- a/src/labelformat/formats/yolov8.py
+++ b/src/labelformat/formats/yolov8.py
@@ -1,7 +1,7 @@
 import logging
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Iterable, List
+from typing import Iterable, List, Optional
 
 import yaml
 
@@ -41,6 +41,9 @@ class _YOLOv8BaseInput:
     def __init__(self, input_file: Path, input_split: str) -> None:
         self._config_file = input_file
         self._split = input_split
+        # Optional hook to tolerate unreadable images during folder scan.
+        # Default None re-raises; see utils.get_images_from_folder.
+        self.on_error: Optional[utils.OnImageErrorHook] = None
         with self._config_file.open() as file:
             self._config_data = yaml.safe_load(file)
 
@@ -56,7 +59,9 @@ class _YOLOv8BaseInput:
             yield Category(id=category_id, name=names[category_id])
 
     def get_images(self) -> Iterable[Image]:
-        yield from utils.get_images_from_folder(folder=self._images_dir())
+        yield from utils.get_images_from_folder(
+            folder=self._images_dir(), on_error=self.on_error
+        )
 
     def _root_dir(self) -> Path:
         """Return the root directory of the dataset.

--- a/src/labelformat/utils.py
+++ b/src/labelformat/utils.py
@@ -1,7 +1,7 @@
 import logging
 import posixpath
 from pathlib import Path, PurePosixPath
-from typing import Iterable, Tuple
+from typing import Callable, Iterable, Optional, Tuple
 from urllib.parse import urlsplit
 
 import fsspec
@@ -46,9 +46,21 @@ JPEG_SOF_MARKERS = {
 
 
 class ImageDimensionError(Exception):
-    """Raised when unable to extract image dimensions using fast methods."""
+    """Raised when unable to extract image dimensions.
 
-    pass
+    Carries the offending image path (when available) so callers and error
+    hooks can identify which file failed.
+    """
+
+    def __init__(self, message: str, path: Optional[PathLike] = None) -> None:
+        super().__init__(message)
+        self.path = path
+
+
+# Hook invoked when an image cannot be read during a folder scan. Receives the
+# offending path and the raised ImageDimensionError. Returning normally skips
+# the file; raising propagates.
+OnImageErrorHook = Callable[[Path, ImageDimensionError], None]
 
 
 def _path_suffix(path: PathLike) -> str:
@@ -177,18 +189,32 @@ def get_image_dimensions(image_path: PathLike) -> Tuple[int, int]:
         except ImageDimensionError:
             pass
 
-    with fsspec.open(str(image_path), "rb") as img_file:
-        with PIL.Image.open(img_file) as img:
-            return img.size
+    try:
+        with fsspec.open(str(image_path), "rb") as img_file:
+            with PIL.Image.open(img_file) as img:
+                return img.size
+    except (PIL.UnidentifiedImageError, OSError) as error:
+        raise ImageDimensionError(
+            f"Failed to read image dimensions for '{image_path}': {error}",
+            path=image_path,
+        ) from error
 
 
-def get_images_from_folder(folder: PathLike) -> Iterable[Image]:
+def get_images_from_folder(
+    folder: PathLike,
+    on_error: Optional[OnImageErrorHook] = None,
+) -> Iterable[Image]:
     """Yields an Image structure for all images in the given folder.
 
     The order of the images is arbitrary. Images in nested folders are included.
 
     Args:
         folder: Path or URI to the folder containing images.
+        on_error: Optional hook invoked when an image cannot be read. When
+            ``None`` (the default), a failure raises ``ImageDimensionError`` and
+            aborts iteration. When provided, the hook is called with the
+            offending path and the error, and the file is skipped so iteration
+            continues.
     """
     image_id = 0
     logger.debug(f"Listing images in '{folder}'...")
@@ -205,7 +231,13 @@ def get_images_from_folder(folder: PathLike) -> Iterable[Image]:
             continue
         image_filename = _relative_path(path=image_path, root=fs_folder)
         image_uri = fs.unstrip_protocol(image_path)
-        image_width, image_height = get_image_dimensions(image_uri)
+        try:
+            image_width, image_height = get_image_dimensions(image_uri)
+        except ImageDimensionError as error:
+            if on_error is None:
+                raise
+            on_error(Path(image_uri), error)
+            continue
         yield Image(
             id=image_id,
             filename=image_filename,

--- a/tests/integration/test_maskpair_integration.py
+++ b/tests/integration/test_maskpair_integration.py
@@ -11,6 +11,7 @@ from numpy.typing import NDArray
 
 from labelformat.formats.coco import COCOInstanceSegmentationOutput
 from labelformat.formats.maskpair import MaskPairInstanceSegmentationInput
+from labelformat.utils import ImageDimensionError
 
 
 def create_test_data(base_path: Path) -> None:
@@ -268,47 +269,13 @@ class TestMaskPairIntegration:
 
 
 class TestMaskPairOnError:
-    def _make_data_with_broken_image(self, base_path: Path) -> None:
-        images_dir = base_path / "images"
-        masks_dir = base_path / "masks"
-        images_dir.mkdir(parents=True)
-        masks_dir.mkdir(parents=True)
-
-        # One valid image/mask pair.
-        image = np.random.randint(100, 200, (100, 100, 3), dtype=np.uint8)
-        cv2.imwrite(str(images_dir / "good.jpg"), image)
-        good_mask: NDArray[np.uint8] = np.zeros((100, 100), dtype=np.uint8)
-        good_mask[20:40, 20:40] = 255
-        cv2.imwrite(str(masks_dir / "good.png"), good_mask)
-
-        # One broken image with a valid mask (so the pair is matched).
-        (images_dir / "broken.jpg").write_bytes(b"not a valid jpeg")
-        broken_mask: NDArray[np.uint8] = np.zeros((100, 100), dtype=np.uint8)
-        broken_mask[10:30, 10:30] = 255
-        cv2.imwrite(str(masks_dir / "broken.png"), broken_mask)
-
-    def _make_input(self, tmp_path: Path) -> MaskPairInstanceSegmentationInput:
-        self._make_data_with_broken_image(tmp_path)
-        return MaskPairInstanceSegmentationInput(
-            image_glob="images/*.jpg",
-            mask_glob="masks/*.png",
-            base_path=tmp_path,
-            pairing_mode="stem",
-            category_names="object",
-            min_area=10.0,
-        )
-
     def test_reraises_by_default(self, tmp_path: Path) -> None:
-        from labelformat.utils import ImageDimensionError
-
-        maskpair_input = self._make_input(tmp_path)
+        maskpair_input = _make_on_error_input(tmp_path)
         with pytest.raises(ImageDimensionError):
             list(maskpair_input.get_images())
 
     def test_hook_skips_broken_image_in_get_images(self, tmp_path: Path) -> None:
-        from labelformat.utils import ImageDimensionError
-
-        maskpair_input = self._make_input(tmp_path)
+        maskpair_input = _make_on_error_input(tmp_path)
         errors: List[Tuple[Path, ImageDimensionError]] = []
         maskpair_input.on_error = lambda path, error: errors.append((path, error))
 
@@ -319,8 +286,41 @@ class TestMaskPairOnError:
         assert isinstance(errors[0][1], ImageDimensionError)
 
     def test_hook_skips_broken_image_in_get_labels(self, tmp_path: Path) -> None:
-        maskpair_input = self._make_input(tmp_path)
+        maskpair_input = _make_on_error_input(tmp_path)
         maskpair_input.on_error = lambda path, error: None
 
         labels = list(maskpair_input.get_labels())
         assert [label.image.filename for label in labels] == ["good.jpg"]
+
+
+def _make_data_with_broken_image(base_path: Path) -> None:
+    """Create one valid image/mask pair and one broken image with a valid mask."""
+    images_dir = base_path / "images"
+    masks_dir = base_path / "masks"
+    images_dir.mkdir(parents=True)
+    masks_dir.mkdir(parents=True)
+
+    # One valid image/mask pair.
+    image = np.random.randint(100, 200, (100, 100, 3), dtype=np.uint8)
+    cv2.imwrite(str(images_dir / "good.jpg"), image)
+    good_mask: NDArray[np.uint8] = np.zeros((100, 100), dtype=np.uint8)
+    good_mask[20:40, 20:40] = 255
+    cv2.imwrite(str(masks_dir / "good.png"), good_mask)
+
+    # One broken image with a valid mask (so the pair is matched).
+    (images_dir / "broken.jpg").write_bytes(b"not a valid jpeg")
+    broken_mask: NDArray[np.uint8] = np.zeros((100, 100), dtype=np.uint8)
+    broken_mask[10:30, 10:30] = 255
+    cv2.imwrite(str(masks_dir / "broken.png"), broken_mask)
+
+
+def _make_on_error_input(tmp_path: Path) -> MaskPairInstanceSegmentationInput:
+    _make_data_with_broken_image(tmp_path)
+    return MaskPairInstanceSegmentationInput(
+        image_glob="images/*.jpg",
+        mask_glob="masks/*.png",
+        base_path=tmp_path,
+        pairing_mode="stem",
+        category_names="object",
+        min_area=10.0,
+    )

--- a/tests/integration/test_maskpair_integration.py
+++ b/tests/integration/test_maskpair_integration.py
@@ -267,8 +267,6 @@ class TestMaskPairIntegration:
         assert len(categories) > 0
         # Default category should be created in the get_labels method
 
-
-class TestMaskPairOnError:
     def test_get_images__reraises_by_default(self, tmp_path: Path) -> None:
         maskpair_input = _make_on_error_input(tmp_path)
         with pytest.raises(ImageDimensionError):

--- a/tests/integration/test_maskpair_integration.py
+++ b/tests/integration/test_maskpair_integration.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List, Tuple
 
 import cv2
 import numpy as np
@@ -265,3 +265,62 @@ class TestMaskPairIntegration:
         # Should create a default category
         assert len(categories) > 0
         # Default category should be created in the get_labels method
+
+
+class TestMaskPairOnError:
+    def _make_data_with_broken_image(self, base_path: Path) -> None:
+        images_dir = base_path / "images"
+        masks_dir = base_path / "masks"
+        images_dir.mkdir(parents=True)
+        masks_dir.mkdir(parents=True)
+
+        # One valid image/mask pair.
+        image = np.random.randint(100, 200, (100, 100, 3), dtype=np.uint8)
+        cv2.imwrite(str(images_dir / "good.jpg"), image)
+        good_mask: NDArray[np.uint8] = np.zeros((100, 100), dtype=np.uint8)
+        good_mask[20:40, 20:40] = 255
+        cv2.imwrite(str(masks_dir / "good.png"), good_mask)
+
+        # One broken image with a valid mask (so the pair is matched).
+        (images_dir / "broken.jpg").write_bytes(b"not a valid jpeg")
+        broken_mask: NDArray[np.uint8] = np.zeros((100, 100), dtype=np.uint8)
+        broken_mask[10:30, 10:30] = 255
+        cv2.imwrite(str(masks_dir / "broken.png"), broken_mask)
+
+    def _make_input(self, tmp_path: Path) -> MaskPairInstanceSegmentationInput:
+        self._make_data_with_broken_image(tmp_path)
+        return MaskPairInstanceSegmentationInput(
+            image_glob="images/*.jpg",
+            mask_glob="masks/*.png",
+            base_path=tmp_path,
+            pairing_mode="stem",
+            category_names="object",
+            min_area=10.0,
+        )
+
+    def test_reraises_by_default(self, tmp_path: Path) -> None:
+        from labelformat.utils import ImageDimensionError
+
+        maskpair_input = self._make_input(tmp_path)
+        with pytest.raises(ImageDimensionError):
+            list(maskpair_input.get_images())
+
+    def test_hook_skips_broken_image_in_get_images(self, tmp_path: Path) -> None:
+        from labelformat.utils import ImageDimensionError
+
+        maskpair_input = self._make_input(tmp_path)
+        errors: List[Tuple[Path, ImageDimensionError]] = []
+        maskpair_input.on_error = lambda path, error: errors.append((path, error))
+
+        images = list(maskpair_input.get_images())
+        assert [img.filename for img in images] == ["good.jpg"]
+        assert len(errors) == 1
+        assert Path(errors[0][0]).name == "broken.jpg"
+        assert isinstance(errors[0][1], ImageDimensionError)
+
+    def test_hook_skips_broken_image_in_get_labels(self, tmp_path: Path) -> None:
+        maskpair_input = self._make_input(tmp_path)
+        maskpair_input.on_error = lambda path, error: None
+
+        labels = list(maskpair_input.get_labels())
+        assert [label.image.filename for label in labels] == ["good.jpg"]

--- a/tests/integration/test_maskpair_integration.py
+++ b/tests/integration/test_maskpair_integration.py
@@ -269,12 +269,12 @@ class TestMaskPairIntegration:
 
 
 class TestMaskPairOnError:
-    def test_reraises_by_default(self, tmp_path: Path) -> None:
+    def test_get_images__reraises_by_default(self, tmp_path: Path) -> None:
         maskpair_input = _make_on_error_input(tmp_path)
         with pytest.raises(ImageDimensionError):
             list(maskpair_input.get_images())
 
-    def test_hook_skips_broken_image_in_get_images(self, tmp_path: Path) -> None:
+    def test_get_images__on_error_hook_skips_broken_image(self, tmp_path: Path) -> None:
         maskpair_input = _make_on_error_input(tmp_path)
         errors: List[Tuple[Path, ImageDimensionError]] = []
         maskpair_input.on_error = lambda path, error: errors.append((path, error))
@@ -285,7 +285,7 @@ class TestMaskPairOnError:
         assert Path(errors[0][0]).name == "broken.jpg"
         assert isinstance(errors[0][1], ImageDimensionError)
 
-    def test_hook_skips_broken_image_in_get_labels(self, tmp_path: Path) -> None:
+    def test_get_labels__on_error_hook_skips_broken_image(self, tmp_path: Path) -> None:
         maskpair_input = _make_on_error_input(tmp_path)
         maskpair_input.on_error = lambda path, error: None
 

--- a/tests/unit/formats/semantic_segmentation/test_pascalvoc.py
+++ b/tests/unit/formats/semantic_segmentation/test_pascalvoc.py
@@ -26,6 +26,7 @@ from labelformat.model.instance_segmentation import (
     SingleInstanceSegmentation,
 )
 from labelformat.model.multipolygon import MultiPolygon
+from labelformat.utils import ImageDimensionError
 from tests.unit.test_utils import FIXTURES_DIR
 
 FIXTURES_ROOT_PASCALVOC = FIXTURES_DIR / "semantic_segmentation/pascalvoc"
@@ -182,28 +183,8 @@ class TestPascalVOCSemanticSegmentationInput:
                 class_id_to_name=_load_class_mapping_int_keys(),
             )
 
-    def _make_dataset_with_broken_image(
-        self, tmp_path: Path
-    ) -> "tuple[Path, Path, Dict[int, str]]":
-        images_dir = tmp_path / "JPEGImages"
-        masks_dir = tmp_path / "SegmentationClass"
-        images_dir.mkdir(parents=True)
-        masks_dir.mkdir(parents=True)
-
-        PILImage.new("RGB", (10, 20), color="blue").save(images_dir / "good.jpg")
-        PILImage.new("L", (10, 20), color=0).save(masks_dir / "good.png")
-
-        (images_dir / "broken.jpg").write_bytes(b"not a valid jpeg")
-        PILImage.new("L", (10, 20), color=0).save(masks_dir / "broken.png")
-
-        return images_dir, masks_dir, {0: "background"}
-
     def test_from_dirs__reraises_by_default(self, tmp_path: Path) -> None:
-        from labelformat.utils import ImageDimensionError
-
-        images_dir, masks_dir, class_map = self._make_dataset_with_broken_image(
-            tmp_path
-        )
+        images_dir, masks_dir, class_map = _make_dataset_with_broken_image(tmp_path)
         with pytest.raises(ImageDimensionError):
             PascalVOCSemanticSegmentationInput.from_dirs(
                 images_dir=images_dir,
@@ -212,11 +193,7 @@ class TestPascalVOCSemanticSegmentationInput:
             )
 
     def test_from_dirs__on_error_hook_skips_broken_image(self, tmp_path: Path) -> None:
-        from labelformat.utils import ImageDimensionError
-
-        images_dir, masks_dir, class_map = self._make_dataset_with_broken_image(
-            tmp_path
-        )
+        images_dir, masks_dir, class_map = _make_dataset_with_broken_image(tmp_path)
         errors: List[Tuple[Path, ImageDimensionError]] = []
         ds = PascalVOCSemanticSegmentationInput.from_dirs(
             images_dir=images_dir,
@@ -506,3 +483,21 @@ def test__validate_mask__non_2d_mask_raises() -> None:
         pascalvoc_module._validate_mask(
             image_obj=img, mask_np=mask, valid_class_ids=valid_ids
         )
+
+
+def _make_dataset_with_broken_image(
+    tmp_path: Path,
+) -> Tuple[Path, Path, Dict[int, str]]:
+    """Create a Pascal VOC dataset with one valid and one corrupt image."""
+    images_dir = tmp_path / "JPEGImages"
+    masks_dir = tmp_path / "SegmentationClass"
+    images_dir.mkdir(parents=True)
+    masks_dir.mkdir(parents=True)
+
+    PILImage.new("RGB", (10, 20), color="blue").save(images_dir / "good.jpg")
+    PILImage.new("L", (10, 20), color=0).save(masks_dir / "good.png")
+
+    (images_dir / "broken.jpg").write_bytes(b"not a valid jpeg")
+    PILImage.new("L", (10, 20), color=0).save(masks_dir / "broken.png")
+
+    return images_dir, masks_dir, {0: "background"}

--- a/tests/unit/formats/semantic_segmentation/test_pascalvoc.py
+++ b/tests/unit/formats/semantic_segmentation/test_pascalvoc.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Dict, Iterable
+from typing import Dict, Iterable, List, Tuple
 from uuid import uuid4
 
 import cv2
@@ -181,6 +181,55 @@ class TestPascalVOCSemanticSegmentationInput:
                 masks_dir=masks_tmp,
                 class_id_to_name=_load_class_mapping_int_keys(),
             )
+
+    def _make_dataset_with_broken_image(
+        self, tmp_path: Path
+    ) -> "tuple[Path, Path, Dict[int, str]]":
+        images_dir = tmp_path / "JPEGImages"
+        masks_dir = tmp_path / "SegmentationClass"
+        images_dir.mkdir(parents=True)
+        masks_dir.mkdir(parents=True)
+
+        PILImage.new("RGB", (10, 20), color="blue").save(images_dir / "good.jpg")
+        PILImage.new("L", (10, 20), color=0).save(masks_dir / "good.png")
+
+        (images_dir / "broken.jpg").write_bytes(b"not a valid jpeg")
+        PILImage.new("L", (10, 20), color=0).save(masks_dir / "broken.png")
+
+        return images_dir, masks_dir, {0: "background"}
+
+    def test_from_dirs__reraises_by_default(self, tmp_path: Path) -> None:
+        from labelformat.utils import ImageDimensionError
+
+        images_dir, masks_dir, class_map = self._make_dataset_with_broken_image(
+            tmp_path
+        )
+        with pytest.raises(ImageDimensionError):
+            PascalVOCSemanticSegmentationInput.from_dirs(
+                images_dir=images_dir,
+                masks_dir=masks_dir,
+                class_id_to_name=class_map,
+            )
+
+    def test_from_dirs__on_error_hook_skips_broken_image(self, tmp_path: Path) -> None:
+        from labelformat.utils import ImageDimensionError
+
+        images_dir, masks_dir, class_map = self._make_dataset_with_broken_image(
+            tmp_path
+        )
+        errors: List[Tuple[Path, ImageDimensionError]] = []
+        ds = PascalVOCSemanticSegmentationInput.from_dirs(
+            images_dir=images_dir,
+            masks_dir=masks_dir,
+            class_id_to_name=class_map,
+            on_error=lambda path, error: errors.append((path, error)),
+        )
+
+        images = list(ds.get_images())
+        assert [img.filename for img in images] == ["good.jpg"]
+        assert len(errors) == 1
+        assert Path(errors[0][0]).name == "broken.jpg"
+        assert isinstance(errors[0][1], ImageDimensionError)
 
     def test_get_mask__unknown_image_raises(self) -> None:
         ds = PascalVOCSemanticSegmentationInput.from_dirs(

--- a/tests/unit/formats/test_yolov8.py
+++ b/tests/unit/formats/test_yolov8.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Callable, Dict, List, Tuple, TypedDict, Union
 
+import PIL.Image
 import pytest
 import yaml
 
 from labelformat.formats.yolov8 import _YOLOv8BaseInput
 from labelformat.model.category import Category
+from labelformat.utils import ImageDimensionError
 
 
 class YOLOv8Config(TypedDict, total=False):
@@ -276,34 +278,14 @@ class Test_YOLOv8BaseInput:
             )
 
     class Test_OnError:
-        def _make_dataset(self, tmp_path: Path) -> Path:
-            import PIL.Image
-
-            images_dir = tmp_path / "images"
-            images_dir.mkdir()
-            PIL.Image.new("RGB", (10, 20), color="blue").save(
-                images_dir / "good.jpg", "JPEG"
-            )
-            (images_dir / "broken.jpg").write_bytes(b"not a valid jpeg")
-
-            config: YOLOv8Config = {"train": "images", "names": ["person"]}
-            config_file = tmp_path / "data.yaml"
-            with config_file.open("w") as f:
-                yaml.safe_dump(config, f)
-            return config_file
-
         def test_reraises_by_default(self, tmp_path: Path) -> None:
-            from labelformat.utils import ImageDimensionError
-
-            config_file = self._make_dataset(tmp_path)
+            config_file = _make_on_error_dataset(tmp_path)
             input_obj = _YOLOv8BaseInput(input_file=config_file, input_split="train")
             with pytest.raises(ImageDimensionError):
                 list(input_obj.get_images())
 
         def test_hook_skips_unreadable_image(self, tmp_path: Path) -> None:
-            from labelformat.utils import ImageDimensionError
-
-            config_file = self._make_dataset(tmp_path)
+            config_file = _make_on_error_dataset(tmp_path)
             input_obj = _YOLOv8BaseInput(input_file=config_file, input_split="train")
 
             errors: List[Tuple[Path, ImageDimensionError]] = []
@@ -314,3 +296,17 @@ class Test_YOLOv8BaseInput:
             assert len(errors) == 1
             assert Path(errors[0][0]).name == "broken.jpg"
             assert isinstance(errors[0][1], ImageDimensionError)
+
+
+def _make_on_error_dataset(tmp_path: Path) -> Path:
+    """Create a YOLOv8 dataset with one valid and one corrupt image."""
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+    PIL.Image.new("RGB", (10, 20), color="blue").save(images_dir / "good.jpg", "JPEG")
+    (images_dir / "broken.jpg").write_bytes(b"not a valid jpeg")
+
+    config: YOLOv8Config = {"train": "images", "names": ["person"]}
+    config_file = tmp_path / "data.yaml"
+    with config_file.open("w") as f:
+        yaml.safe_dump(config, f)
+    return config_file

--- a/tests/unit/formats/test_yolov8.py
+++ b/tests/unit/formats/test_yolov8.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable, Dict, List, TypedDict, Union
+from typing import Callable, Dict, List, Tuple, TypedDict, Union
 
 import pytest
 import yaml
@@ -274,3 +274,43 @@ class Test_YOLOv8BaseInput:
             assert (
                 input_obj._labels_dir().resolve() == (parent_dir / "labels").resolve()
             )
+
+    class Test_OnError:
+        def _make_dataset(self, tmp_path: Path) -> Path:
+            import PIL.Image
+
+            images_dir = tmp_path / "images"
+            images_dir.mkdir()
+            PIL.Image.new("RGB", (10, 20), color="blue").save(
+                images_dir / "good.jpg", "JPEG"
+            )
+            (images_dir / "broken.jpg").write_bytes(b"not a valid jpeg")
+
+            config: YOLOv8Config = {"train": "images", "names": ["person"]}
+            config_file = tmp_path / "data.yaml"
+            with config_file.open("w") as f:
+                yaml.safe_dump(config, f)
+            return config_file
+
+        def test_reraises_by_default(self, tmp_path: Path) -> None:
+            from labelformat.utils import ImageDimensionError
+
+            config_file = self._make_dataset(tmp_path)
+            input_obj = _YOLOv8BaseInput(input_file=config_file, input_split="train")
+            with pytest.raises(ImageDimensionError):
+                list(input_obj.get_images())
+
+        def test_hook_skips_unreadable_image(self, tmp_path: Path) -> None:
+            from labelformat.utils import ImageDimensionError
+
+            config_file = self._make_dataset(tmp_path)
+            input_obj = _YOLOv8BaseInput(input_file=config_file, input_split="train")
+
+            errors: List[Tuple[Path, ImageDimensionError]] = []
+            input_obj.on_error = lambda path, error: errors.append((path, error))
+
+            images = list(input_obj.get_images())
+            assert [img.filename for img in images] == ["good.jpg"]
+            assert len(errors) == 1
+            assert Path(errors[0][0]).name == "broken.jpg"
+            assert isinstance(errors[0][1], ImageDimensionError)

--- a/tests/unit/formats/test_yolov8.py
+++ b/tests/unit/formats/test_yolov8.py
@@ -278,13 +278,15 @@ class Test_YOLOv8BaseInput:
             )
 
     class Test_OnError:
-        def test_reraises_by_default(self, tmp_path: Path) -> None:
+        def test_get_images__reraises_by_default(self, tmp_path: Path) -> None:
             config_file = _make_on_error_dataset(tmp_path)
             input_obj = _YOLOv8BaseInput(input_file=config_file, input_split="train")
             with pytest.raises(ImageDimensionError):
                 list(input_obj.get_images())
 
-        def test_hook_skips_unreadable_image(self, tmp_path: Path) -> None:
+        def test_get_images__on_error_hook_skips_unreadable_image(
+            self, tmp_path: Path
+        ) -> None:
             config_file = _make_on_error_dataset(tmp_path)
             input_obj = _YOLOv8BaseInput(input_file=config_file, input_split="train")
 

--- a/tests/unit/formats/test_yolov8.py
+++ b/tests/unit/formats/test_yolov8.py
@@ -116,6 +116,27 @@ class Test_YOLOv8BaseInput:
             with pytest.raises(TypeError):  # Will fail when trying to use len() on int
                 list(input_obj.get_categories())
 
+    def test_get_images__reraises_by_default(self, tmp_path: Path) -> None:
+        config_file = _make_on_error_dataset(tmp_path)
+        input_obj = _YOLOv8BaseInput(input_file=config_file, input_split="train")
+        with pytest.raises(ImageDimensionError):
+            list(input_obj.get_images())
+
+    def test_get_images__on_error_hook_skips_unreadable_image(
+        self, tmp_path: Path
+    ) -> None:
+        config_file = _make_on_error_dataset(tmp_path)
+        input_obj = _YOLOv8BaseInput(input_file=config_file, input_split="train")
+
+        errors: List[Tuple[Path, ImageDimensionError]] = []
+        input_obj.on_error = lambda path, error: errors.append((path, error))
+
+        images = list(input_obj.get_images())
+        assert [img.filename for img in images] == ["good.jpg"]
+        assert len(errors) == 1
+        assert Path(errors[0][0]).name == "broken.jpg"
+        assert isinstance(errors[0][1], ImageDimensionError)
+
     class Test_RootDir:
         def test_resolves_root_dir_with_explicit_path(self, tmp_path: Path) -> None:
             dataset_dir = tmp_path / "dataset"
@@ -276,28 +297,6 @@ class Test_YOLOv8BaseInput:
             assert (
                 input_obj._labels_dir().resolve() == (parent_dir / "labels").resolve()
             )
-
-    class Test_OnError:
-        def test_get_images__reraises_by_default(self, tmp_path: Path) -> None:
-            config_file = _make_on_error_dataset(tmp_path)
-            input_obj = _YOLOv8BaseInput(input_file=config_file, input_split="train")
-            with pytest.raises(ImageDimensionError):
-                list(input_obj.get_images())
-
-        def test_get_images__on_error_hook_skips_unreadable_image(
-            self, tmp_path: Path
-        ) -> None:
-            config_file = _make_on_error_dataset(tmp_path)
-            input_obj = _YOLOv8BaseInput(input_file=config_file, input_split="train")
-
-            errors: List[Tuple[Path, ImageDimensionError]] = []
-            input_obj.on_error = lambda path, error: errors.append((path, error))
-
-            images = list(input_obj.get_images())
-            assert [img.filename for img in images] == ["good.jpg"]
-            assert len(errors) == 1
-            assert Path(errors[0][0]).name == "broken.jpg"
-            assert isinstance(errors[0][1], ImageDimensionError)
 
 
 def _make_on_error_dataset(tmp_path: Path) -> Path:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -134,6 +134,16 @@ def test_get_image_dimensions__memory_uri() -> None:
     assert height == 77
 
 
+def test_get_image_dimensions__corrupt_image_raises_image_dimension_error() -> None:
+    image_uri = f"memory://{uuid4().hex}/broken.jpg"
+    with fsspec.open(image_uri, "wb") as file:
+        file.write(b"this is not a valid jpeg")
+
+    with pytest.raises(ImageDimensionError) as exc_info:
+        get_image_dimensions(image_uri)
+    assert exc_info.value.path == image_uri
+
+
 def test_get_images_from_folder__memory_uri() -> None:
     root_uri = f"memory://{uuid4().hex}/dataset"
     image_a = f"{root_uri}/a.jpg"
@@ -157,16 +167,6 @@ def test_get_images_from_folder__memory_uri() -> None:
         12,
         34,
     )
-
-
-def test_get_image_dimensions__corrupt_image_raises_image_dimension_error() -> None:
-    image_uri = f"memory://{uuid4().hex}/broken.jpg"
-    with fsspec.open(image_uri, "wb") as file:
-        file.write(b"this is not a valid jpeg")
-
-    with pytest.raises(ImageDimensionError) as exc_info:
-        get_image_dimensions(image_uri)
-    assert exc_info.value.path == image_uri
 
 
 def test_get_images_from_folder__corrupt_image_reraises_by_default() -> None:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Tuple
+from typing import List, Tuple
 from uuid import uuid4
 
 import fsspec
@@ -157,6 +157,49 @@ def test_get_images_from_folder__memory_uri() -> None:
         12,
         34,
     )
+
+
+def test_get_image_dimensions__corrupt_image_raises_image_dimension_error() -> None:
+    image_uri = f"memory://{uuid4().hex}/broken.jpg"
+    with fsspec.open(image_uri, "wb") as file:
+        file.write(b"this is not a valid jpeg")
+
+    with pytest.raises(ImageDimensionError) as exc_info:
+        get_image_dimensions(image_uri)
+    assert exc_info.value.path == image_uri
+
+
+def test_get_images_from_folder__corrupt_image_reraises_by_default() -> None:
+    root_uri = f"memory://{uuid4().hex}/dataset"
+    with fsspec.open(f"{root_uri}/good.jpg", "wb") as file:
+        PIL.Image.new("RGB", (10, 20), color="blue").save(file, "JPEG")
+    with fsspec.open(f"{root_uri}/broken.jpg", "wb") as file:
+        file.write(b"not a valid jpeg")
+
+    with pytest.raises(ImageDimensionError):
+        list(get_images_from_folder(root_uri))
+
+
+def test_get_images_from_folder__on_error_hook_skips_corrupt_images() -> None:
+    root_uri = f"memory://{uuid4().hex}/dataset"
+    with fsspec.open(f"{root_uri}/good.jpg", "wb") as file:
+        PIL.Image.new("RGB", (10, 20), color="blue").save(file, "JPEG")
+    with fsspec.open(f"{root_uri}/broken.jpg", "wb") as file:
+        file.write(b"not a valid jpeg")
+
+    errors: List[Tuple[Path, ImageDimensionError]] = []
+    images = list(
+        get_images_from_folder(
+            root_uri, on_error=lambda path, error: errors.append((path, error))
+        )
+    )
+
+    assert len(images) == 1
+    assert images[0].filename == "good.jpg"
+    assert len(errors) == 1
+    error_path, error = errors[0]
+    assert Path(error_path).name == "broken.jpg"
+    assert isinstance(error, ImageDimensionError)
 
 
 def _create_test_jpeg(


### PR DESCRIPTION
## Context

This is the upstream `labelformat` change that unblocks the studio-side work.

## Problem

Folder-scanning formats (`yolov8`, `kitti`, `pascalvoc`, `lightly`, `maskpair`) open every image via `get_image_dimensions` → `PIL.Image.open` to read dimensions. A broken/undecodable file raised mid-iteration, and since a generator cannot resume after raising, **one bad file killed** `get_images()` **and** `get_labels()` entirely, propagating a raw `PIL.UnidentifiedImageError`/`OSError`.

## Changes

1. **Normalize the failure.** `get_image_dimensions` (`utils.py`) now wraps the fallback `PIL.Image.open` and raises a typed `ImageDimensionError` carrying the offending path instead of a raw PIL/OS error.
2. **Add an opt-in error hook.** `get_images_from_folder` gains `on_error: Callable[[Path, ImageDimensionError], None] | None = None`. Default `None` → re-raise (no behavior change). When set: invoke `on_error(path, error)` and skip the file so the generator survives.
3. **Expose the hook on the folder-based readers.** Settable `on_error` attribute on `yolov8`, `kitti`, `lightly`, `maskpair`; `on_error` parameter on `pascalvoc.from_dirs` (its scan happens at construction). `maskpair.get_labels` was kept aligned so dropped images don't break label lookup.

Default behavior stays `raise`; tolerance is strictly opt-in.

## Testing

- New unit tests for the typed error + hook in `utils`, and per-format tests for yolov8, pascalvoc, and maskpair (including get_labels alignment).
- Full suite passes (164 passed, 1 skipped), `mypy` clean, `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)